### PR TITLE
Fixed support for IE 8

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -23,6 +23,7 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$parse', 
 
   return {
     restrict: 'EA',
+		replace: true,
     scope: {
       selectedObject: '=',
       localData: '=',


### PR DESCRIPTION
Adding the 'replace' property allows the directive to render in IE 8.
