### PR TITLE
Fixed bug which showed "No results" just before showing results

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ var app = angular.module('app', ["angucomplete-alt"]);
 | :------------- |:-------------| :-----:| :-----|
 | id | A unique ID for the field | Yes | members |
 | placeholder | Placeholder text for the search field | No | Search members |
-| pause | The time to wait (in milliseconds) before searching when the user enters new characters | No | 400 |
+| pause | Max time waiting for the response | No | 500 |
 | selected-object | Either an object in your scope or callback function. If you set an object, it will be two-way-bound data as usual. If you set a callback, it gets called when selection is made. | Yes | selectedObject or objectSelectedCallback |
 | remote-url | The remote URL to hit to query for results in JSON. angucomplete will automatically append the search string on the end of this, so it must be a GET request | No | http://myserver.com/api/users/find?searchstr= |
 | remote-url-data-field | The name of the field in the JSON object returned back that holds the Array of objects to be used for the autocomplete list. | No | results |

--- a/README.md
+++ b/README.md
@@ -29,8 +29,15 @@ To see a demo go here: http://ghiden.github.io/angucomplete-alt
     * Another callback function: when the input value changes.
 
 ### Getting Started
-Download the code, and include the angucomplete-alt.js file in your page. Then add the angucomplete-alt module to your Angular App file, e.g.
-```html
+Download the package, and include the angucomplete-alt.js file in your page.
+
+```bash
+bower install angucomplete-alt --save
+```
+
+Then add the angucomplete-alt module to your Angular App file, e.g.
+
+```js
 var app = angular.module('app', ["angucomplete-alt"]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,17 +26,11 @@ To see a demo go here: http://ghiden.github.io/angucomplete-alt
 * You can either bind an object or callback function
     * bind an object: it works as regular two-way-data-binding
     * callback function: when a selection is made by user, this callback is called with the selected object. Thanks to @nekcih for proposing this feature.
+    * Another callback function: when the input value changes.
 
 ### Getting Started
-Download the package, and include the angucomplete-alt.js file in your page.
-
-```bash
-bower install angucomplete-alt --save
-```
-
-Then add the angucomplete-alt module to your Angular App file, e.g.
-
-```js
+Download the code, and include the angucomplete-alt.js file in your page. Then add the angucomplete-alt module to your Angular App file, e.g.
+```html
 var app = angular.module('app', ["angucomplete-alt"]);
 ```
 
@@ -90,4 +84,4 @@ var app = angular.module('app', ["angucomplete-alt"]);
 | remote-url-response-formatter | A function on the scope that will modify raw response from remote API before it is rendered in the drop-down.  Useful for adding data that may not be available from the API.  The specified function must return the object in the format that angucomplete understands. | No | addImageUrlToObject |
 | clear-selected | To clear out input field upon selecting an item, set this attribute to true. | No | true |
 | override-suggestions | To override suggestions and set the value in input field to selectedObject | No | true |
-
+| writting-callback | Callback to a custom function every time the input value changes | No | callBack |

--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -204,7 +204,7 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$parse', 
               image: image,
               originalObject: responseData[i]
             };
-
+              scope.searching=false;
           }
 
 
@@ -235,14 +235,14 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$parse', 
               }
             }
 
-            scope.searching = false;
+
             scope.processResults(matches, str);
 
           } else if (scope.remoteUrlRequestFormatter) {
             params = scope.remoteUrlRequestFormatter(str);
             $http.get(scope.remoteUrl, {params: params}).
               success(function(responseData, status, headers, config) {
-                scope.searching = false;
+
                 scope.processResults(
                   extractValue(responseFormatter(responseData), scope.remoteUrlDataField), str
                 );
@@ -254,7 +254,7 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$parse', 
           } else {
             $http.get(scope.remoteUrl + str, {}).
               success(function(responseData, status, headers, config) {
-                scope.searching = false;
+
                 scope.processResults(
                   extractValue(responseFormatter(responseData), scope.remoteUrlDataField), str
                 );
@@ -297,6 +297,7 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$parse', 
             scope.showDropdown = false;
             lastSearchTerm = null;
           } else if (isNewSearchNeeded(scope.searchStr, lastSearchTerm)) {
+              scope.searching = true;
             lastSearchTerm = scope.searchStr;
             scope.showDropdown = true;
             scope.currentIndex = -1;
@@ -306,11 +307,10 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$parse', 
               $timeout.cancel(searchTimer);
             }
 
-            scope.searching = true;
-
-            searchTimer = $timeout(function() {
               scope.searchTimerComplete(scope.searchStr);
-            }, scope.pause);
+              searchTimer = $timeout(function() {
+                  scope.searching = false;
+              }, scope.pause);
           }
         } else {
           event.preventDefault();

--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -28,6 +28,7 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$parse', 
       localData: '=',
       remoteUrlRequestFormatter: '=',
       remoteUrlResponseFormatter: '=',
+      writtingCallback: '=',
       id: '@',
       placeholder: '@',
       remoteUrl: '@',
@@ -45,7 +46,7 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$parse', 
     },
     template:
       '<div class="angucomplete-holder">' +
-      '  <input id="{{id}}_value" ng-model="searchStr" type="text" placeholder="{{placeholder}}" class="{{inputClass}}" ng-focus="resetHideResults()" ng-blur="hideResults()"/>' +
+      '  <input id="{{id}}_value" ng-model="searchStr" type="text" placeholder="{{placeholder}}" class="{{inputClass}}" ng-focus="resetHideResults()" ng-blur="hideResults()" ng-change="callChange()"/>' +
       '  <div id="{{id}}_dropdown" class="angucomplete-dropdown" ng-if="showDropdown">' +
       '    <div class="angucomplete-searching" ng-show="searching">Searching...</div>' +
       '    <div class="angucomplete-searching" ng-show="!searching && (!results || results.length == 0)">No results found</div>' +
@@ -136,6 +137,12 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$parse', 
         }
         return $sce.trustAsHtml(result);
       };
+
+       if(scope.writtingCallback){
+           scope.callChange = function(){
+            scope.writtingCallback();
+        }
+       }
 
       if (scope.minlength && scope.minlength !== '') {
         minlength = scope.minlength;


### PR DESCRIPTION
I've discovered that when I use an external api (which could be slower than a local json) and I write slow, the dropdown shows me "No results found" just before I get the result. 
To replicate: 
 - Your json must have something which matches "butterflies"
 - Slowly type "butterflies"
This happens because the $timeout sometimes can't be stopped in time and the last calling still sets scope.searching to false.
In my opinion it makes more sense to call directly to the function and at the same time set a $timeout just in case it couldn't find anything.
