### PR TITLE
Watch initial Value

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -87,6 +87,9 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$parse', 
       scope.currentIndex = null;
       scope.searching = false;
       scope.searchStr = scope.initialValue;
+      scope.$watch('initialValue', function(){
+            scope.searchStr = scope.initialValue;
+        })
 
       // for IE8 quirkiness about event.which
       function ie8EventNormalizer(event) {


### PR DESCRIPTION
When the `initial-value` is being set by an asynchronously loaded  model make sure it gets updated, in most cases when someone is updating an existing model he would request it from some backend before actually populating the form, this is why we need to watch the initial value because at linking time it's always an empty string.
