### PR TITLE
Modify conditions for 'No results found' dropdown

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -206,8 +206,7 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$q', '$pa
       function specialKeyHandler(event) {
         var which = ie8EventNormalizer(event);
         if (which === KEY_ES) {
-          scope.results = [];
-          scope.showDropdown = false;
+          clearResults();
           scope.$apply();
         } else if (which === KEY_BS || which === KEY_DEL) {
           scope.$apply();


### PR DESCRIPTION
This is to fix bug #31 (Pressing Enter without selecting an item results in "No results found" message)
