### PR TITLE
Make `override-suggestions` option work on blur.

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -222,7 +222,9 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$q', '$pa
       function handleOverrideSuggestions(event) {
         if (scope.overrideSuggestions) {
           if (!(scope.selectedObject && scope.selectedObject.originalObject === scope.searchStr)) {
-            event.preventDefault();
+            if (event !== undefined) {
+                event.preventDefault();
+            }
             setInputString(scope.searchStr);
           }
         }
@@ -432,6 +434,7 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$q', '$pa
       scope.hideResults = function() {
         hideTimer = $timeout(function() {
           scope.showDropdown = false;
+          handleOverrideSuggestions();
         }, BLUR_TIMEOUT);
         cancelHttpRequest();
 


### PR DESCRIPTION
Before that patch, `override-suggestions` option worked only
when used have pressed `Enter`. But often, when there are
many fields, user pressed `Tab` or even clicked to another
field. This fix stores entered string in the `selectedObject`
in any case.
