### PR TITLE
Set the form field to valid when the initialValue is added

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -97,6 +97,7 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$q', '$pa
       scope.searchStr = scope.initialValue;
       scope.$watch('initialValue', function(){
         scope.searchStr = scope.initialValue;
+        handleRequired(true);
       });
 
       // for IE8 quirkiness about event.which


### PR DESCRIPTION
if the initialValue is updated after the directive initialises the the required field will have content but not be valid.
