### PR TITLE
Prevent error when value field is not present

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -392,7 +392,7 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$q', '$pa
           match = false;
 
           for (s = 0; s < searchFields.length; s++) {
-            value = extractValue(scope.localData[i], searchFields[s]);
+            value = extractValue(scope.localData[i], searchFields[s]) || '';
             match = match || (value.toLowerCase().indexOf(str.toLowerCase()) >= 0);
           }
 


### PR DESCRIPTION
When, for example, the description field is only present on some items, an error is thrown. This is a simple solution for preventing that error.
