### PR TITLE
Fix #64 to down arrow show all autocomplete list when nothing has been entered

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -104,12 +104,12 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$q', '$pa
 
       scope.$on('angucomplete-alt:clearInput', function (event, elementId) {
         if (!elementId) {
-          scope.searchStr = null;
+          scope.searchStr = "";
           clearResults();
         }
         else { // id is given
           if (scope.id === elementId) {
-            scope.searchStr = null;
+            scope.searchStr = "";
             clearResults();
           }
         }
@@ -141,7 +141,7 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$q', '$pa
         callOrAssign({originalObject: str});
 
         if (scope.clearSelected) {
-          scope.searchStr = null;
+          scope.searchStr = "";
         }
         clearResults();
       }
@@ -521,7 +521,7 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$q', '$pa
         }
 
         if (scope.clearSelected) {
-          scope.searchStr = null;
+          scope.searchStr = "";
         }
         else {
           scope.searchStr = result.title;


### PR DESCRIPTION
Fix #64 
- set the searchStr to empty string when initial-value property is not exist
- fix to down arrow show all autocomplete list when nothing has been entered.
