### PR TITLE
Fix error when description is not present on auto match

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -464,7 +464,7 @@ angular.module('angucomplete-alt', [] ).directive('angucompleteAlt', ['$q', '$pa
 
             if (scope.autoMatch) {
               checkExactMatch(scope.results[scope.results.length-1],
-                  {title: text, desc: description}, scope.searchStr);
+                  {title: text, desc: description || ''}, scope.searchStr);
             }
           }
 


### PR DESCRIPTION
I discovered another bug if the description isn't always present and you've enabled automatch.
