### PR TITLE
Allow the user to set an initial value OBJECT instead of just a strin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ var app = angular.module('app', ["angucomplete-alt"]);
 | field-required-class | Set custom class name for required. | No | "match" |
 | text-searching | Custom string to show when search is in progress. | No | "Searching for items..." |
 | text-no-results | Custom string to show when there is no match. | No | "Not found" |
-| initial-value | Initial value for internal ng-model. [example](http://ghiden.github.io/angucomplete-alt/#example9) | No | "some string" |
+| initial-value | Initial value for component. If string, the internal model is set to the string value, if an object, the title-field attribute is used to parse the correct title for the view, and the internal model is set to the object. [example](http://ghiden.github.io/angucomplete-alt/#example9) | No | myInitialValue (object/string) |
 | input-changed | A callback function that is called when input field is changed. [example](http://ghiden.github.io/angucomplete-alt/#example10) |  No | inputChangedFn |
 | auto-match | Allows for auto selecting an item if the search text matches a search results attributes exactly. [example](http://ghiden.github.io/angucomplete-alt/#example11) |  No | true |
 | focus-in | A function or expression to be called when input field gets focused. [example](http://ghiden.github.io/angucomplete-alt/#example12) |  No | focusIn() |

--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -73,7 +73,7 @@
       scope: {
         selectedObject: '=',
         disableInput: '=',
-        initialValue: '@',
+        initialValue: '=',
         localData: '=',
         remoteUrlRequestFormatter: '=',
         remoteUrlRequestWithCredentials: '@',
@@ -126,12 +126,21 @@
 
         scope.currentIndex = null;
         scope.searching = false;
-        scope.searchStr = scope.initialValue;
-        unbindInitialValue = scope.$watch('initialValue', function(newval, oldval){
-          if (newval && newval.length > 0) {
-            scope.searchStr = scope.initialValue;
-            handleRequired(true);
+        unbindInitialValue = scope.$watch('initialValue', function(newval, oldval) {
+
+          if (newval) {
             unbindInitialValue();
+
+            if (typeof newval === 'object') {
+              scope.searchStr = extractTitle(newval);
+              callOrAssign({originalObject: newval});
+            } else if (typeof newval === 'string' && newval.length > 0) {
+              scope.searchStr = newval;
+            } else {
+              console.error('Tried to set initial value of angucomplete to', newval, 'which is an invalid value');
+            }
+
+            handleRequired(true);
           }
         });
 
@@ -706,7 +715,7 @@
         // set strings for "Searching..." and "No results"
         scope.textSearching = attrs.textSearching ? attrs.textSearching : TEXT_SEARCHING;
         scope.textNoResults = attrs.textNoResults ? attrs.textNoResults : TEXT_NORESULTS;
-        
+
         // set max length (default to maxlength deault from html
         scope.maxlength = attrs.maxlength ? attrs.maxlength : MAX_LENGTH;
 

--- a/test/angucomplete-alt.spec.js
+++ b/test/angucomplete-alt.spec.js
@@ -35,7 +35,7 @@ describe('angucomplete-alt', function() {
       $scope.$digest();
       expect(element.find('#ex1_value').attr('placeholder')).toEqual('Search countries');
     });
-      
+
     it('should render maxlength string', function() {
       var element = angular.element('<div angucomplete-alt id="ex1" placeholder="Search countries" selected-object="selectedCountry" local-data="countries" search-fields="name" title-field="name" maxlength="25" />');
       $scope.selectedCountry = null;
@@ -996,7 +996,7 @@ describe('angucomplete-alt', function() {
 
   describe('initial value', function() {
     it('should set initial value', function() {
-      var element = angular.element('<div angucomplete-alt id="ex1" placeholder="Search countries" selected-object="countrySelected" local-data="countries" search-fields="name" title-field="name" minlength="1" initial-value="{{initialValue}}"/>');
+      var element = angular.element('<div angucomplete-alt id="ex1" placeholder="Search countries" selected-object="countrySelected" local-data="countries" search-fields="name" title-field="name" minlength="1" initial-value="initialValue"/>');
       $scope.countries = [
         {name: 'Afghanistan', code: 'AF'},
         {name: 'Aland Islands', code: 'AX'},
@@ -1011,8 +1011,33 @@ describe('angucomplete-alt', function() {
       expect(element.isolateScope().searchStr).toBe('Japan');
     });
 
+    it('should set initial value', function() {
+
+      var element = angular.element('<div angucomplete-alt id="ex1" placeholder="Search countries" selected-object="grabCountryCode" local-data="countries" search-fields="name" title-field="name" minlength="1" initial-value="initialValue"/>');
+
+      $scope.countryCode = null;
+      $scope.grabCountryCode = function(value) {
+        $scope.countryCode = value.originalObject.code;
+      };
+
+      $scope.countries = [
+        {name: 'Afghanistan', code: 'AF'},
+        {name: 'Aland Islands', code: 'AX'},
+        {name: 'Albania', code: 'AL'}
+      ];
+      $compile(element)($scope);
+      $scope.$digest();
+
+      $scope.initialValue = {name: 'Aland Islands', code: 'AX'};
+      $scope.$digest();
+
+      expect(element.isolateScope().searchStr).toBe('Aland Islands');
+      expect($scope.countryCode).toBe('AX');
+
+    });
+
     it('should set validity to true', function() {
-      var element = angular.element('<form name="form"><div angucomplete-alt id="ex1" placeholder="Search countries" selected-object="countrySelected" local-data="countries" search-fields="name" title-field="name" minlength="1" initial-value="{{initialValue}}" field-required="true"/></form>');
+      var element = angular.element('<form name="form"><div angucomplete-alt id="ex1" placeholder="Search countries" selected-object="countrySelected" local-data="countries" search-fields="name" title-field="name" minlength="1" initial-value="initialValue" field-required="true"/></form>');
       $scope.countries = [
         {name: 'Afghanistan', code: 'AF'},
         {name: 'Aland Islands', code: 'AX'},


### PR DESCRIPTION
…g, from which angucomplete will extract the field's search string value in the expected manner.

The justification for this change is:

- The user can two-way bind the initial model (#26 and #18)
- The user can use this component to update an existing domain model which uses objects as fields and only stores a reference to the object.
- Simply setting the searchStr (old behaviour) doesn't call the selectedObject function which means the model which backs components never gets updated
