### PR TITLE
Small fix necessary if you set initital-value to be your ng-model but…

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -165,6 +165,7 @@
         }
 
         function callOrAssign(value) {
+          unbindInitialValue();
           if (typeof scope.selectedObject === 'function') {
             scope.selectedObject(value);
           }


### PR DESCRIPTION
… also update your ng-model as a result of making a selection. Essentially we must unbind the initial-value function in two scenarios - either if an initial-value is set, or if an item is selected.

Apologies for this one - spotted it as I was rolling out the new version across my site.