### PR TITLE
compat with angular 1.4.5

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -10,15 +10,16 @@
 'use strict';
 
 (function (root, factory) {
-  if (typeof module !== 'undefined' && module.exports) {
+  if (root.angular) {
+    // Global Variables
+    factory(root.angular);
+  }
+  else if (typeof module !== 'undefined' && module.exports) {
     // CommonJS
     module.exports = factory(require('angular'));
   } else if (typeof define === 'function' && define.amd) {
     // AMD
     define(['angular'], factory);
-  } else {
-    // Global Variables
-    factory(root.angular);
   }
 }(window, function (angular) {
 


### PR DESCRIPTION
# require('angular') yields empty object with bower/browserify

Look at [this file](https://github.com/angular/bower-angular/blob/master/angular.js): the angular module define `window.angular`. When `require`ing angular, it would return an empty object instead of what we want