### PR TITLE
New config param searchMethod to customize search behaviour

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -492,7 +492,18 @@
 
           for (s = 0; s < searchFields.length; s++) {
             value = extractValue(scope.localData[i], searchFields[s]) || '';
-            match = match || (value.toString().toLowerCase().indexOf(str.toString().toLowerCase()) >= 0);
+            var lowerValue = value.toString().toLowerCase();
+            var lowerSearch = str.toString().toLowerCase();
+
+            if (typeof scope.$parent[scope.searchMethod] === "function") {
+            match = match || scope.$parent[scope.searchMethod](str, value);
+            } else if(scope.searchMethod === 'startsWith') {
+                match = match || (lowerValue.indexOf(lowerSearch) === 0);
+            } else if(scope.searchMethod === 'endsWith') {
+                match = match || (lowerValue.indexOf(lowerSearch, lowerValue.length - lowerSearch.length) !== -1);
+            } else {
+                match = match || (lowerValue.indexOf(lowerSearch) >= 0);
+            }
           }
 
           if (match) {
@@ -765,6 +776,7 @@
         inputClass: '@',
         pause: '@',
         searchFields: '@',
+        searchMethod: '@',
         minlength: '@',
         matchClass: '@',
         clearSelected: '@',


### PR DESCRIPTION
As mentioned in https://github.com/ghiden/angucomplete-alt/issues/255 I've added a parameter to customize search behaviour.

Currently supported:
* contains (default)
* startsWith
* endsWith
* custom matcher callback in parent $scope

Custom methods would look something like this:
```$scope.myCustomMatcher = function(search, actual) {...}```

Take a look at it, I've tested it locally and works fine for me.