### PR TITLE
enhancing the angucomplete-alt by allowing originalObject to be used as the selectedObject.

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -167,6 +167,15 @@
         if (typeof scope.selectedObject === 'function') {
           scope.selectedObject(value);
         }
+        // use the originalObject as the selectedObject
+        else if (scope.useOriginalObject === 'true'){
+          // handles null and undefined value
+          if(value == null){
+            scope.selectedObject = value;
+          } else {
+            scope.selectedObject = value.originalObject;
+          }
+        }
         else {
           scope.selectedObject = value;
         }
@@ -807,7 +816,8 @@
         focusOut: '&',
         focusIn: '&',
         inputName: '@',
-        focusFirst: '@'
+        focusFirst: '@',
+        useOriginalObject: '@'
       },
       templateUrl: function(element, attrs) {
         return attrs.templateUrl || TEMPLATE_URL;


### PR DESCRIPTION
By default, when a object is selected, the scope.selectedObject is set to the angucomplete wrapper. The original object is nested in selectedObject.originalObject. This PR allows the originalObject to be used as the value when "useOriginalObject" scope parameter is passed in as 'true'. 

This removes the need to create custom selectedObject functions to extract the originalObject and sets it in the scope.