### PR TITLE
Move strict directive

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -7,8 +7,6 @@
 
 /*! Copyright (c) 2014 Hidenari Nozaki and contributors | Licensed under the MIT license */
 
-'use strict';
-
 (function (root, factory) {
   if (typeof module !== 'undefined' && module.exports) {
     // CommonJS
@@ -21,6 +19,7 @@
     factory(root.angular);
   }
 }(window, function (angular) {
+  'use strict';
 
   angular.module('angucomplete-alt', []).directive('angucompleteAlt', ['$q', '$parse', '$http', '$sce', '$timeout', '$templateCache', '$interpolate', function ($q, $parse, $http, $sce, $timeout, $templateCache, $interpolate) {
     // keyboard events


### PR DESCRIPTION
Some projects may not be strict compliant and as is concatenating this file will enforce strict globally.  This should be scoped to this component.