### PR TITLE
stop displaying 'searching' message on error

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -440,6 +440,8 @@
       }
 
       function httpErrorCallback(errorRes, status, headers, config) {
+        scope.searching = false;
+        
         // cancelled/aborted
         if (status === 0 || status === -1) { return; }
 


### PR DESCRIPTION
If there is an error in the background, the user continues to wait, since the 'searching' message continues to be displayed