### PR TITLE
Added ngModel

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -811,7 +811,8 @@
         fieldTabindex: '@',
         inputName: '@',
         focusFirst: '@',
-        parseInput: '&'
+        parseInput: '&',
+        searchStr: '=ngModel'
       },
       templateUrl: function(element, attrs) {
         return attrs.templateUrl || TEMPLATE_URL;


### PR DESCRIPTION
made ng-model available in field.

Use case:  Form asking user to add their favorite grocery store.  User has a grocery store that is not in the list.  User should still be allowed to submit their favorite grocery store even though not in the list.

This allows ng-model so input data can be captured.