### PR TITLE
Don´t perform search if tabbing a field with previously selected value

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -29,6 +29,7 @@
     var KEY_UP  = 38;
     var KEY_LF  = 37;
     var KEY_ES  = 27;
+    var KEY_SHIFT = 16;
     var KEY_EN  = 13;
     var KEY_TAB =  9;
 
@@ -252,6 +253,10 @@
         if (which === KEY_UP || which === KEY_EN) {
           event.preventDefault();
         }
+        else if((which === KEY_TAB || which === KEY_SHIFT) && scope.selectedObject && scope.selectedObject.originalObject) {
+          // Don´t search if tabbed into field with valid object selection
+          event.preventDefault();
+        }
         else if (which === KEY_DW) {
           event.preventDefault();
           if (!scope.showDropdown && scope.searchStr && scope.searchStr.length >= minlength) {
@@ -266,6 +271,7 @@
             inputField.val(scope.searchStr);
           });
         }
+
         else {
           if (minlength === 0 && !scope.searchStr) {
             return;

--- a/test/angucomplete-alt.spec.js
+++ b/test/angucomplete-alt.spec.js
@@ -7,6 +7,7 @@ describe('angucomplete-alt', function() {
       KEY_ES  = 27,
       KEY_EN  = 13,
       KEY_DEL = 46,
+      KEY_SHIFT = 16,
       KEY_TAB =  9,
       KEY_BS  =  8;
 
@@ -1251,6 +1252,44 @@ describe('angucomplete-alt', function() {
       inputField.trigger('input');
       inputField.trigger(eKeyup);
       expect(element.find('.angucomplete-row').length).toBe(3);
+    });
+
+    it('should not query again if tab or shift keyup in input field and input is allready valid', function () {
+      var element = angular.element('<div angucomplete-alt id="ex1" placeholder="Search countries" selected-object="selectedCountry" local-data="countries" search-fields="name" title-field="name" minlength="1"/>');
+      $scope.selectedCountry = undefined;
+      $scope.countries = [
+        {name: 'Afghanistan', code: 'AF'},
+        {name: 'Aland Islands', code: 'AX'},
+        {name: 'Albania', code: 'AL'}
+      ];
+      $compile(element)($scope);
+      $scope.$digest();
+
+      var inputField = element.find('#ex1_value');
+      var eKeyup = $.Event('keyup');
+      eKeyup.which = 97; // letter: a
+
+      inputField.val('a');
+      inputField.trigger('input');
+      inputField.trigger(eKeyup);
+      $timeout.flush();
+      expect(element.find('#ex1_dropdown').length).toBe(1);
+
+      var eKeydown = $.Event('keydown');
+      eKeydown.which = KEY_TAB;
+      inputField.trigger(eKeydown);
+      $scope.$digest();
+      expect($scope.selectedCountry.originalObject).toEqual($scope.countries[0]);
+
+      eKeyup.which = KEY_TAB;
+      inputField.trigger(eKeyup);
+      $scope.$digest();
+      expect(element.find('#ex1_dropdown').hasClass('ng-hide')).toBeTruthy();
+
+      eKeyup.which = KEY_SHIFT;
+      inputField.trigger(eKeyup);
+      $scope.$digest();
+      expect(element.find('#ex1_dropdown').hasClass('ng-hide')).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
When tabbing to a field which has been previously populated with a valid auto complete result the following happens:
1. A new search takes place.
2. If the displayed title differs from the accepted search parameters the drop down saying "No results found" will also be displayed.

This PR prevents this unnecessary(?) search to happen.