### PR TITLE
Fix for browsers input with off or false

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -42,11 +42,18 @@
     var TEXT_SEARCHING = 'Searching...';
     var TEXT_NORESULTS = 'No results found';
     var TEMPLATE_URL = '/angucomplete-alt/index.html';
-
+    
+    //fix for different browsers that uses off or false for input params
+    var INPUT_PARAM_OFF="off";
+    if($window && $window.navigator && $window.navigator.userAgent){
+    	var USERAGENT = $window.navigator.userAgent;
+		  if(USERAGENT.indexOf("Chrome")!=-1) INPUT_PARAM_OFF="false";
+    }
+    
     // Set the default template for this directive
     $templateCache.put(TEMPLATE_URL,
         '<div class="angucomplete-holder" ng-class="{\'angucomplete-dropdown-visible\': showDropdown}">' +
-        '  <input id="{{id}}_value" name="{{inputName}}" tabindex="{{fieldTabindex}}" ng-class="{\'angucomplete-input-not-empty\': notEmpty}" ng-model="searchStr" ng-disabled="disableInput" type="{{inputType}}" placeholder="{{placeholder}}" maxlength="{{maxlength}}" ng-focus="onFocusHandler()" class="{{inputClass}}" ng-focus="resetHideResults()" ng-blur="hideResults($event)" autocapitalize="off" autocorrect="off" autocomplete="off" ng-change="inputChangeHandler(searchStr)"/>' +
+        '  <input id="{{id}}_value" name="{{inputName}}" ng-class="{\'angucomplete-input-not-empty\': notEmpty}" ng-model="searchStr" ng-disabled="disableInput" type="{{inputType}}" placeholder="{{placeholder}}" maxlength="{{maxlength}}" ng-focus="onFocusHandler()" class="{{inputClass}}" ng-focus="resetHideResults()" ng-blur="hideResults($event)" autocapitalize="'+INPUT_PARAM_OFF+'" autocorrect="'+INPUT_PARAM_OFF+'" autocomplete="'+INPUT_PARAM_OFF+'" ng-change="inputChangeHandler(searchStr)"/>' +
         '  <div id="{{id}}_dropdown" class="angucomplete-dropdown" ng-show="showDropdown">' +
         '    <div class="angucomplete-searching" ng-show="searching" ng-bind="textSearching"></div>' +
         '    <div class="angucomplete-searching" ng-show="!searching && (!results || results.length == 0)" ng-bind="textNoResults"></div>' +


### PR DESCRIPTION
Fix for different browsers that uses off or false for input params.

In my case i had problems with autocomplete fields where browsers suggests a name. 

To set autocomplete in safari and firefox it works with autocomplete="off" , but in case of chrome it works with autocomplete="false" (tested in OSx)

Need to test in differents browsers and OS to make sure better configuration.. but for now it fixes for Chrome