### PR TITLE
Add attribute to allow showing the entire dropdown whenever input is focused

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -633,7 +633,7 @@
         if (scope.focusIn) {
           scope.focusIn();
         }
-        if (minlength === 0 && (!scope.searchStr || scope.searchStr.length === 0)) {
+        if (scope.dropdownOnFocus || (minlength === 0 && (!scope.searchStr || scope.searchStr.length === 0))) {
           scope.currentIndex = scope.focusFirst ? 0 : scope.currentIndex;
           scope.showDropdown = true;
           showAll();
@@ -799,6 +799,7 @@
         pause: '@',
         searchFields: '@',
         minlength: '@',
+        dropdownOnFocus: '@',
         matchClass: '@',
         clearSelected: '@',
         overrideSuggestions: '@',

--- a/example/index.html
+++ b/example/index.html
@@ -45,6 +45,7 @@
           <li><a href="#example14">Example 14 - Custom Template</a></li>
           <li><a href="#example15">Example 15 - Clear Input on Button Click</a></li>
           <li><a href="#example16">Example 16 - Change Input on Button Click</a></li>
+          <li><a href="#example17">Example 17 - Show Dropdown on Click</a></li>
         </ul>
       </div>
 
@@ -640,6 +641,50 @@
         <div class="result">
           <div ng-show="selectedCountry16">
             You selected <span class="bold-span">{{selectedCountry16.originalObject.name}}</span> <span ng-show="selectedCountry16.originalObject.code">which has a country code of <span class="bold-span">{{selectedCountry16.originalObject.code}}</span></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="large-padded-row">
+        <h3><a name="example17" class="page-anchor">Example 16 - Show dropdown on click</a></h3>
+        <div class="padded-row">
+<pre>
+&lt;div angucomplete-alt id="ex17"
+   placeholder="Search countries"
+   maxlength="50"
+   pause="100"
+   selected-object="selectedCountry17"
+   initial-value="selectedCountry17"
+   local-data="countries"
+   search-fields="name"
+   title-field="name"
+   minlength="1"
+   dropdown-on-focus="true"
+   input-class="form-control form-control-small"
+   match-class="highlight"&gt;
+&lt;/div&gt;
+</pre>
+        </div>
+        <div class="padded-row">
+          <div angucomplete-alt id="ex17"
+               placeholder="Search countries"
+               maxlength="50"
+               pause="100"
+               selected-object="selectedCountry17"
+               initial-value="selectedCountry17"
+               local-data="countries"
+               search-fields="name"
+               title-field="name"
+               minlength="1"
+               dropdown-on-focus="true"
+               input-class="form-control form-control-small"
+               match-class="highlight">
+          </div>
+        </div>
+
+        <div class="result">
+          <div ng-show="selectedCountry17">
+            You selected <span class="bold-span">{{selectedCountry17.originalObject.name}}</span> <span ng-show="selectedCountry17.originalObject.code">which has a country code of <span class="bold-span">{{selectedCountry17.originalObject.code}}</span></span>
           </div>
         </div>
       </div>

--- a/example/js/app.js
+++ b/example/js/app.js
@@ -289,6 +289,7 @@ app.controller('MainController', ['$scope', '$http', '$rootScope',
     }
 
     $scope.selectedCountry16 = {name: 'Russia'};
+    $scope.selectedCountry17 = {name: 'Russia'};
 
     $scope.inputChanged = function(str) {
       $scope.console10 = str;

--- a/test/angucomplete-alt.spec.js
+++ b/test/angucomplete-alt.spec.js
@@ -1615,6 +1615,43 @@ describe('angucomplete-alt', function() {
       expect(element.find('.angucomplete-row').length).toBe(3);
     });
   });
+  describe('set dropdown-on-focus to true', function() {
+    it('should show all items when focused', function() {
+      var element = angular.element('<div angucomplete-alt id="ex1" placeholder="Search countries" selected-object="countrySelected" local-data="countries" search-fields="name" title-field="name" minlength="1" dropdown-on-focus="true"/>');
+      $scope.countrySelected = null;
+      $scope.countries = [
+        {name: 'Afghanistan', code: 'AF'},
+        {name: 'Aland Islands', code: 'AX'},
+        {name: 'Albania', code: 'AL'}
+      ];
+      $compile(element)($scope);
+      $scope.$digest();
+
+      var inputField = element.find('#ex1_value');
+      expect(element.find('.angucomplete-row').length).toBe(0);
+      // TODO: should replace all triggers with this triggerHandler
+      // http://sravi-kiran.blogspot.co.nz/2013/12/TriggeringEventsInAngularJsDirectiveTests.html
+      inputField.triggerHandler('focus');
+      $scope.$digest();
+      expect(element.find('.angucomplete-row').length).toBe(3);
+    });
+
+    it('should still show all items on focus even if one was already selected', function() {
+      var element = angular.element('<div angucomplete-alt id="ex1" placeholder="Search countries" selected-object="countrySelected" local-data="countries" search-fields="name" title-field="name" minlength="1" dropdown-on-focus="true"/>');
+      $scope.countries = [
+        {name: 'Afghanistan', code: 'AF'},
+        {name: 'Aland Islands', code: 'AX'},
+        {name: 'Albania', code: 'AL'}
+      ];
+      $scope.countrySelected = $scope.countries[0];
+      $compile(element)($scope);
+      $scope.$digest();
+      var inputField = element.find('#ex1_value');
+      inputField.triggerHandler('focus');
+      $scope.$digest();
+      expect(element.find('.angucomplete-row').length).toBe(3);
+    });
+  });
 
   describe('Numeric data', function() {
     it('should handle nemeric data', function() {


### PR DESCRIPTION
I had a need to be able to have the input behave more like a 'select' (but with typeahead), which basically means that no matter what content is in place, on click/focus it should show the full dropdown.

I added this as a new option that can be set on the directive as 'dropdownOnFocus' (dropdown-on-focus)  I added tests and example.

No worries if you don't want this feature and decide not to merge.  Alternatively, if you'd like it but would prefer I clean up/change mechanism let me know.  I'm relatively new to angular so I may not have done this quite right.