### PR TITLE
textSearching and textNoResult params at runtime

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -790,6 +790,8 @@
         id: '@',
         type: '@',
         placeholder: '@',
+        textSearching: '@',
+        textNoResults: '@',
         remoteUrl: '@',
         remoteUrlDataField: '@',
         titleField: '@',


### PR DESCRIPTION
I did this little change to allow the user to change the Texts used while searching and when no results are found at runtime.

This little edit is useful if, for example, you need to manage a multi-language site and have to control each string of the directive.