### PR TITLE
Validate str is a non empty string before comparing it to the title

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -538,7 +538,7 @@
       function checkExactMatch(result, obj, str){
         if (!str) { return false; }
         for(var key in obj){
-          if(obj[key].toLowerCase() === str.toLowerCase()){
+          if((typeof str === 'string' && str) && obj[key].toLowerCase() === str.toLowerCase()){
             scope.selectResult(result);
             return true;
           }


### PR DESCRIPTION
I tried to set `minlength="0"` and `auto-match="true"` - using a local search, but I had an exception, and as a result, the first item in my local list was the one that always selected by the `angucomplete-alt` control. This fixes the problem.