### PR TITLE
angucomplete-alt now exports the module name.

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -834,5 +834,6 @@
       }
     };
   }]);
-
+  
+  return "angucomplete-alt";
 }));


### PR DESCRIPTION
This is to be compliant with angular + webpack/browserify related work environments.
