### PR TITLE
Add type checking for str parameter in inputChangeHandler

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -699,7 +699,7 @@
       };
 
       scope.inputChangeHandler = function(str) {
-        if (str.length < minlength) {
+        if (typeof str !== 'string' || str.length < minlength) {
           cancelHttpRequest();
           clearResults();
         }


### PR DESCRIPTION
Add type checking for str parameter in inputChangeHandler to prevent function from crashing if undefined was sent

![bug](https://dl.dropboxusercontent.com/u/36906193/10%20sem/Screenshot%20from%202016-07-08%2015%3A59%3A56.png)  
this error rise when I type something in input and then delete everything using backspace.   
![my implementation](https://dl.dropboxusercontent.com/u/36906193/10%20sem/Screenshot%20from%202016-07-08%2016%3A22%3A40.png)  
I'm not sure that it's not my bad, but anyway with additional checking it became more reliable =)
Can't catch the same bug in examples, even with remote data.
**Tests are ok**