### PR TITLE
change to use promises instead of success/catch.

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -481,8 +481,8 @@
         params.timeout = httpCanceller.promise;
         httpCallInProgress = true;
         $http.get(url, params)
-          .success(httpSuccessCallbackGen(str))
-          .error(httpErrorCallback)
+          .then(httpSuccessCallbackGen(str))
+          .catch(httpErrorCallback)
           .finally(function(){httpCallInProgress=false;});
       }
 


### PR DESCRIPTION
Since the `.success` and `.error` methods are deprecated in angular1.5, this update will remove the deprecated methods.