### PR TITLE
prevent selected-object value changed when TAB is pressed

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -821,7 +821,8 @@
         fieldTabindex: '@',
         inputName: '@',
         focusFirst: '@',
-        parseInput: '&'
+        parseInput: '&',
+        searchStr: '=ngModel'
       },
       templateUrl: function(element, attrs) {
         return attrs.templateUrl || TEMPLATE_URL;

--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -29,6 +29,7 @@
     var KEY_UP  = 38;
     var KEY_LF  = 37;
     var KEY_ES  = 27;
+    var KEY_SHIFT = 16;
     var KEY_EN  = 13;
     var KEY_TAB =  9;
 
@@ -411,6 +412,9 @@
               scope.selectResult(scope.results[scope.currentIndex]);
               scope.$digest();
             }
+          }
+          else if (scope.selectedObject && scope.selectedObject.originalObject) {
+//              nothing todo, good to go
           }
           else {
             // no results


### PR DESCRIPTION
when selected-object already contain valid value, then don't do
handleOverrideSuggestions which will make the selected-object being
override.

i think the handleOverrideSuggestions logic is wrong when there is
already a valid selected-object