### PR TITLE
prevent selected-object value changed when TAB is pressed

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -821,7 +821,8 @@
         fieldTabindex: '@',
         inputName: '@',
         focusFirst: '@',
-        parseInput: '&'
+        parseInput: '&',
+        searchStr: '=ngModel'
       },
       templateUrl: function(element, attrs) {
         return attrs.templateUrl || TEMPLATE_URL;

--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -412,6 +412,9 @@
               scope.$digest();
             }
           }
+          else if (scope.selectedObject && scope.selectedObject.originalObject) {
+//              nothing todo, good to go
+          }
           else {
             // no results
             // intentionally not sending event so that it does not


### PR DESCRIPTION
when selected-object already contain valid value, then don't do
handleOverrideSuggestions which will make the selected-object being
override.

i think the handleOverrideSuggestions logic is wrong when there is
already a valid selected-object

