### PR TITLE
fix: Fix calls to removed $http .success() and .error() methods

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -481,8 +481,8 @@
         params.timeout = httpCanceller.promise;
         httpCallInProgress = true;
         $http.get(url, params)
-          .success(httpSuccessCallbackGen(str))
-          .error(httpErrorCallback)
+          .then(httpSuccessCallbackGen(str))
+          .catch(httpErrorCallback)
           .finally(function(){httpCallInProgress=false;});
       }
 


### PR DESCRIPTION
The legacy .success() and .error() methods have finally been
removed on Angular 1.6.

See: https://github.com/angular/angular.js/commit/b54a39e2029005e0572fbd2ac0e8f6a4e5d69014