### PR TITLE
Handle "disabled" attribute on page load

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -81,6 +81,13 @@
       var displaySearching;
       var displayNoResults;
 
+      if (elem.attr('disabled')) {
+        $timeout(function() {
+          inputField.attr('disabled', 'disabled');
+          scope.disableInput = true;
+        }, 0);
+      }
+
       elem.on('mousedown', function(event) {
         if (event.target.id) {
           mousedownOn = event.target.id;

--- a/example/index.html
+++ b/example/index.html
@@ -453,7 +453,7 @@ $scope.localSearch = function(str, people) {
 
       <div class="large-padded-row">
 
-        <h3><a name="example13" class="page-anchor">Example 13 - Disable/Enable Input<span class="console">disable <input type="checkbox" ng-model="disableInput"></span></a></h3>
+        <h3><a name="example13" class="page-anchor">Example 13 - Disable/Enable Input</a><span class="console">disable <input type="checkbox" ng-model="disableInput"></span></h3>
         <div class="padded-row">
 <pre>
 &lt;div angucomplete-alt


### PR DESCRIPTION
If the angucomplete-alt tag has the "disabled" HTML attribute set on it when the page loads, then also the inner input field will receive this attribute and the disableInput scope variable is set to true.

Furthermore, the example no. 13 has been fixed since the checkbox was not working after the first time.