### PR TITLE
removed unbindInitialValue to allow new values keep watching

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -77,7 +77,6 @@
       var dd = elem[0].querySelector('.angucomplete-dropdown');
       var isScrollOn = false;
       var mousedownOn = null;
-      var unbindInitialValue;
       var displaySearching;
       var displayNoResults;
 
@@ -95,10 +94,8 @@
 
       scope.currentIndex = scope.focusFirst ? 0 : null;
       scope.searching = false;
-      unbindInitialValue = scope.$watch('initialValue', function(newval) {
+      scope.$watch('initialValue', function(newval) {
         if (newval) {
-          // remove scope listener
-          unbindInitialValue();
           // change input
           handleInputChange(newval, true);
         }


### PR DESCRIPTION
When the watcher for initialValue is removed, if the value changes in the scope is not updated, so you get the latest value - 1, and that doesn't work if you are getting the initial value from a service hitting an API.