### PR TITLE
Preventing override on blur after auto-match

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -185,12 +185,14 @@
       }
 
       function setInputString(str) {
-        callOrAssign({originalObject: str});
+        if(!scope.exactMatch) {
+          callOrAssign({originalObject: str});
 
-        if (scope.clearSelected) {
-          scope.searchStr = null;
+          if (scope.clearSelected) {
+            scope.searchStr = null;
+          }
+          clearResults();
         }
-        clearResults();
       }
 
       function extractTitle(data) {
@@ -398,7 +400,7 @@
             });
           }
         } else if (which === KEY_TAB) {
-          if (scope.results && scope.results.length > 0 && scope.showDropdown) {
+          if (scope.results && scope.showDropdown) {
             if (scope.currentIndex === -1 && scope.overrideSuggestions) {
               // intentionally not sending event so that it does not
               // prevent default tab behavior
@@ -416,7 +418,7 @@
             // no results
             // intentionally not sending event so that it does not
             // prevent default tab behavior
-            if (scope.searchStr && scope.searchStr.length > 0) {
+            if (scope.searchStr) {
               handleOverrideSuggestions();
             }
           }
@@ -542,10 +544,12 @@
         if (!str) { return false; }
         for(var key in obj){
           if(obj[key].toLowerCase() === str.toLowerCase()){
+            scope.exactMatch = true;
             scope.selectResult(result);
             return true;
           }
         }
+        scope.exactMatch = false;
         return false;
       }
 
@@ -576,7 +580,7 @@
       function processResults(responseData, str) {
         var i, description, image, text, formattedText, formattedDesc;
 
-        if (responseData && responseData.length > 0) {
+        if (responseData) {
           scope.results = [];
 
           for (i = 0; i < responseData.length; i++) {
@@ -658,7 +662,7 @@
           hideTimer = $timeout(function() {
             clearResults();
             scope.$apply(function() {
-              if (scope.searchStr && scope.searchStr.length > 0) {
+              if (scope.searchStr) {
                 inputField.val(scope.searchStr);
               }
             });
@@ -670,7 +674,7 @@
           }
 
           if (scope.overrideSuggestions) {
-            if (scope.searchStr && scope.searchStr.length > 0 && scope.currentIndex === -1) {
+            if (scope.searchStr && scope.currentIndex === -1) {
               handleOverrideSuggestions();
             }
           }

--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -90,6 +90,9 @@
         }
         else {
           mousedownOn = event.target.className;
+          if(event.target.innerText === scope.textNoResults) {
+            scope.hideResults(event);
+          }
         }
       });
 

--- a/test/angucomplete-alt.spec.js
+++ b/test/angucomplete-alt.spec.js
@@ -955,6 +955,34 @@ describe('angucomplete-alt', function() {
 
       expect(element.isolateScope().searchStr).toBe(null);
     });
+	
+    it('should not override on tab keydown when a selection has auto-matched and input text has not changed', function() {
+      var element = angular.element('<div angucomplete-alt id="ex1" placeholder="Search countries" selected-object="selectedCountry" local-data="countries" search-fields="name" title-field="name" minlength="1" override-suggestions="true" auto-match="true"/>');
+      $scope.selectedCountry = undefined;
+      $scope.countries = [
+        {name: 'Afghanistan', code: 'AF'},
+        {name: 'Aland Islands', code: 'AX'},
+        {name: 'Albania', code: 'AL'}
+      ];
+      $compile(element)($scope);
+      $scope.$digest();
+
+      var inputField = element.find('#ex1_value');
+      var e = $.Event('keyup');
+      e.which = 97; // letter: a
+
+      inputField.val('Albania');
+      inputField.trigger('input');
+      inputField.trigger(e);
+      $timeout.flush();
+      expect($scope.selectedCountry.originalObject).toEqual($scope.countries[2]);
+
+      var eKeydown = $.Event('keydown');
+      eKeydown.which = KEY_TAB;
+      inputField.trigger(eKeydown);
+      inputField.blur();
+      expect($scope.selectedCountry.originalObject).toEqual($scope.countries[2]);
+    });
   });
 
   describe('selectedObject callback', function() {


### PR DESCRIPTION
When override-suggestions and auto-match are both true, a match on
originalObject occurs but is then overridden with a custom object on
blur. This change sets a flag when an exact match is found that prevents
override until the input text changes. Includes a test case that fails
with old code but passes with these changes.

This fix addresses issue #387 .