### PR TITLE
Prevent extractValue from blowing up on undefined

### DIFF
--- a/angucomplete-alt.js
+++ b/angucomplete-alt.js
@@ -208,7 +208,9 @@
           keys= key.split('.');
           result = obj;
           for (var i = 0; i < keys.length; i++) {
-            result = result[keys[i]];
+            if (result) {
+              result = result[keys[i]];
+            }
           }
         }
         else {


### PR DESCRIPTION
Given that angucomplete-alt supports passing a `.` separated key in `image-field` (and other fields), this fix will prevent an error in the case of an undefined value.

That is, given:
```
let data = [{
    // ...
    id: 1,
    logo: undefined,
    // ...
} , {
    // ...
    id: 2,
    logo: {
        thumbnail: '/img/users/portrait.png'}
    }
}]
```
and passing `image-field="logo.thumbnail" local-data="data"` to angucomplete-alt, this currently causes an error on the first item: `TypeError: Cannot read property 'thumbnail' of undefined`, and no further items are rendered in the autocomplete dropdown.

This PR just adds a check to see if the current value exists before attempting to access the property.

Came across this in the course of work, just thought I'd submit this fix for you (worked around it locally). Let me know if you need me to do more to improve the PR, but it seems fairly trivial.

Regards, 
Callum